### PR TITLE
Add mappers to the test sources

### DIFF
--- a/mapstruct-rounding/pom.xml
+++ b/mapstruct-rounding/pom.xml
@@ -26,7 +26,7 @@
     <version>1.0.0</version>
 
     <properties>
-        <org.mapstruct.version>1.0.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.2.0.Beta1</org.mapstruct.version>
     </properties>
 
     <dependencies>

--- a/mapstruct-updatemethods-1/pom.xml
+++ b/mapstruct-updatemethods-1/pom.xml
@@ -26,7 +26,7 @@
     <version>1.0.0</version>
 
     <properties>
-        <org.mapstruct.version>1.0.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.2.0-SNAPSHOT</org.mapstruct.version>
     </properties>
 
     <dependencies>
@@ -72,6 +72,15 @@
                         <phase>generate-sources</phase>
                         <goals>
                             <goal>process</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <!-- This execution is needed if you want the processor plugin to
+                        generate the mappers in the test sources. -->
+                        <id>process-test</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>process-test</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/mapstruct-updatemethods-1/src/test/java/org/mapstruct/example/SourceTargetTestMapperTest.java
+++ b/mapstruct-updatemethods-1/src/test/java/org/mapstruct/example/SourceTargetTestMapperTest.java
@@ -1,0 +1,133 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.example;
+
+import org.junit.Test;
+import org.mapstruct.example.dto.MammalDto;
+import org.mapstruct.example.dto.MammalEntity;
+import org.mapstruct.example.mapper.SourceTargetTestMapper;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+
+/**
+ * This is a copy of {@link SourceTargetMapperTest} to demonstrate the usage of Mappers in the test sources.
+ *
+ * @author Filip Hrisafov
+ */
+public class SourceTargetTestMapperTest {
+
+
+    /**
+     * Test if everything is working when sources are present
+     */
+    @Test
+    public void test() {
+
+        MammalDto s = new MammalDto();
+        s.setNumberOfLegs( 4 );
+
+        MammalEntity t = new MammalEntity();
+
+        // its a cow ;)
+        SourceTargetTestMapper.MAPPER.toTarget( s, 3L, t );
+
+        assertThat( t.getNumberOfLegs() ).isEqualTo( 4 );
+        assertThat( t.getNumberOfStomachs() ).isEqualTo( 3 );
+
+    }
+
+
+    /**
+     * Leave source null
+     */
+    @Test
+    public void testSourceIsNull() {
+
+        MammalDto s = null;
+
+        MammalEntity t = new MammalEntity();
+
+        // its a cow ;)
+        SourceTargetTestMapper.MAPPER.toTarget( s, 3L, t );
+
+        assertThat( t.getNumberOfLegs() ).isNull();
+        assertThat( t.getNumberOfStomachs() ).isEqualTo( 3 );
+
+    }
+
+    /**
+     * Leave source content is null
+     */
+    @Test
+    public void testSourceContentIsNull() {
+
+        MammalDto s = new MammalDto();
+
+        MammalEntity t = new MammalEntity();
+
+        // its a cow ;)
+        SourceTargetTestMapper.MAPPER.toTarget( s, 3L, t );
+
+        assertThat( t.getNumberOfLegs() ).isNull();
+        assertThat( t.getNumberOfStomachs() ).isEqualTo( 3 );
+
+    }
+
+    /**
+     * Leave non bean parameter is null
+     */
+    @Test
+    public void testSourceNonBeanParameterIsNull() {
+
+        MammalDto s = new MammalDto();
+        s.setNumberOfLegs( 4 );
+
+        MammalEntity t = new MammalEntity();
+
+        // its a cow ;)
+        SourceTargetTestMapper.MAPPER.toTarget( s, null, t );
+
+        assertThat( t.getNumberOfLegs() ).isEqualTo( 4 );
+        assertThat( t.getNumberOfStomachs() ).isNull();
+
+    }
+
+    /**
+     * target pre-initialized
+     */
+    @Test
+    public void testTargetIsPreInitialized() {
+
+
+        MammalDto s = null;
+
+        // lets create a human
+        MammalEntity t = new MammalEntity();
+        t.setNumberOfLegs( 2L );
+        t.setNumberOfStomachs( 1L );
+
+        SourceTargetTestMapper.MAPPER.toTarget( s, null, t );
+
+        // and we have a human
+        assertThat( t.getNumberOfLegs() ).isEqualTo( 2 );
+        assertThat( t.getNumberOfStomachs() ).isEqualTo( 1 );
+
+    }
+}

--- a/mapstruct-updatemethods-1/src/test/java/org/mapstruct/example/mapper/SourceTargetTestMapper.java
+++ b/mapstruct-updatemethods-1/src/test/java/org/mapstruct/example/mapper/SourceTargetTestMapper.java
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.example.mapper;
+
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Mappings;
+import org.mapstruct.example.dto.MammalDto;
+import org.mapstruct.example.dto.MammalEntity;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * This mapper is a copy of {@link SourceTargetMapper} to demonstrate how to use the processor plugin for compiling
+ * mapper in the test sources.
+ *
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface SourceTargetTestMapper {
+
+    SourceTargetTestMapper MAPPER = Mappers.getMapper( SourceTargetTestMapper.class );
+
+    @Mappings({
+        @Mapping(target = "numberOfStomachs", source = "numberOfStomachs")
+    })
+    void toTarget(MammalDto source, Long numberOfStomachs, @MappingTarget MammalEntity target);
+}


### PR DESCRIPTION
Fixes #21.

This PR adds some mappers to the test sources (`src/test/java`) in some of the modules