### PR TITLE
#26 Add example mapping from Map to property

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Currently, the following examples exist:
 * _mapstruct-on-gradle_: Shows how to use MapStruct in Gradle-based projects; to build the example project, run `./gradlew clean build` on the command line
 * _mapstruct-lombok_: Shows how to use MapStruct together with Lombok (with both a Maven `pom.xml` and a Gradle `build.gradle`); to build the example project, run either `mvn clean install` or `./gradlew clean build` on the command line
 * _mapstruct-iterable-non-iterable_: Shows how by means of a mapper util class conversions can be made from an iterable- to its non-iterable element
+* _mapstruct-mapping-from-map_: Shows how by means of a mapper util class and qualifiers extracting value can be carried out on Maps
 * _mapstruct-rounding_: Shows how by means of a mapper util class and qualifiers roundings can be carried out on Numbers
 * _mapstruct-examples-updatemethods-1_: Shows how to update an existing target object
 * _mapstruct-examples-field-mapping_: Shows how MapStruct can be used with "struct" like objects with public fields

--- a/mapstruct-mapping-from-map/pom.xml
+++ b/mapstruct-mapping-from-map/pom.xml
@@ -32,15 +32,18 @@
     <dependencies>
         <dependency>
             <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct</artifactId>
+            <artifactId>mapstruct-jdk8</artifactId>
             <version>${org.mapstruct.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>${org.mapstruct.version}</version>
+            <!-- IntelliJ does not pick up the processor if it is not in the dependencies.
+             There is already an open issue for IntelliJ see https://youtrack.jetbrains.com/issue/IDEA-150621
+            -->
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>
@@ -48,40 +51,19 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.bsc.maven</groupId>
-                <artifactId>maven-processor-plugin</artifactId>
-                <version>2.2.4</version>
-                <configuration>
-                    <defaultOutputDirectory>
-                        ${project.build.directory}/generated-sources
-                    </defaultOutputDirectory>
-                    <processors>
-                        <processor>org.mapstruct.ap.MappingProcessor</processor>
-                    </processors>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>process</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>process</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.mapstruct</groupId>
-                        <artifactId>mapstruct-processor</artifactId>
-                        <version>${org.mapstruct.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${org.mapstruct.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
         </plugins>

--- a/mapstruct-mapping-from-map/pom.xml
+++ b/mapstruct-mapping-from-map/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ and/or other contributors as indicated by the @authors tag. See the
+ copyright.txt file in the distribution for a full listing of all
+ contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.mapstruct.examples.map</groupId>
+    <artifactId>mapstruct-examples-from-map</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <org.mapstruct.version>1.2.0.Beta3</org.mapstruct.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${org.mapstruct.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+                <version>2.2.4</version>
+                <configuration>
+                    <defaultOutputDirectory>
+                        ${project.build.directory}/generated-sources
+                    </defaultOutputDirectory>
+                    <processors>
+                        <processor>org.mapstruct.ap.MappingProcessor</processor>
+                    </processors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>process</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.mapstruct</groupId>
+                        <artifactId>mapstruct-processor</artifactId>
+                        <version>${org.mapstruct.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/mapstruct-mapping-from-map/src/main/java/org/mapstruct/example/dto/Source.java
+++ b/mapstruct-mapping-from-map/src/main/java/org/mapstruct/example/dto/Source.java
@@ -1,0 +1,42 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.example.dto;
+
+import java.util.Map;
+
+/**
+ *
+ * @author Adam Gurgul
+ */
+public class Source {
+
+    private Map<String, Object> map;
+
+    public Map<String, Object> getMap() {
+        return map;
+    }
+
+    public void setMap(Map<String, Object> map) {
+        this.map = map;
+    }
+
+    public Source(Map<String, Object> map) {
+        this.map = map;
+    }
+}

--- a/mapstruct-mapping-from-map/src/main/java/org/mapstruct/example/dto/Target.java
+++ b/mapstruct-mapping-from-map/src/main/java/org/mapstruct/example/dto/Target.java
@@ -1,0 +1,54 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.example.dto;
+
+/**
+ *
+ * @author Adam Gurgul
+ */
+public class Target {
+
+
+    private String ip;
+    private String server;
+
+    public String getIp() {
+        return ip;
+    }
+
+    public void setIp(String ip) {
+        this.ip = ip;
+    }
+
+    public String getServer() {
+        return server;
+    }
+
+    public void setServer(String server) {
+        this.server = server;
+    }
+
+    @Override
+    public String toString() {
+        return "Target{" +
+                "ip='" + ip + '\'' +
+                ", server='" + server + '\'' +
+                '}';
+    }
+}

--- a/mapstruct-mapping-from-map/src/main/java/org/mapstruct/example/mapper/SourceTargetMapper.java
+++ b/mapstruct-mapping-from-map/src/main/java/org/mapstruct/example/mapper/SourceTargetMapper.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.example.mapper;
+
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.example.dto.Source;
+import org.mapstruct.example.dto.Target;
+import org.mapstruct.example.mapper.util.MappingUtil;
+import org.mapstruct.example.mapper.util.MappingUtil.Ip;
+import org.mapstruct.example.mapper.util.MappingUtil.Server;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Adam Gurgul
+ */
+
+@Mapper( uses = MappingUtil.class )
+public interface SourceTargetMapper {
+
+    SourceTargetMapper MAPPER = Mappers.getMapper( SourceTargetMapper.class );
+
+    @Mappings( {
+        @Mapping(source = "map", target = "ip", qualifiedBy = Ip.class ),
+        @Mapping(source = "map", target = "server", qualifiedBy = Server.class ),
+    } )
+    Target toTarget(Source s);
+}

--- a/mapstruct-mapping-from-map/src/main/java/org/mapstruct/example/mapper/util/MappingUtil.java
+++ b/mapstruct-mapping-from-map/src/main/java/org/mapstruct/example/mapper/util/MappingUtil.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ * and/or other contributors as indicated by the @authors tag. See the
+ * copyright.txt file in the distribution for a full listing of all
+ * contributors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mapstruct.example.mapper.util;
+
+import org.mapstruct.Qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Map;
+
+/**
+ * @author Adam Gurgul
+ */
+public class MappingUtil {
+
+    @Qualifier
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface Ip {
+    }
+
+    @Qualifier
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.SOURCE)
+    public static @interface Server {
+    }
+
+    @Ip
+    public String ip(Map<String, Object> in) {
+        return (String) in.get("ip");
+    }
+
+    @Server
+    public String server(Map<String, Object> in) {
+        return (String) in.get("server");
+    }
+
+}

--- a/mapstruct-mapping-from-map/src/test/java/org/mapstruct/example/SourceTargetMapperTest.java
+++ b/mapstruct-mapping-from-map/src/test/java/org/mapstruct/example/SourceTargetMapperTest.java
@@ -1,0 +1,73 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.example;
+
+import org.junit.Test;
+import org.mapstruct.example.dto.Source;
+import org.mapstruct.example.dto.Target;
+import org.mapstruct.example.mapper.SourceTargetMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ *
+ * @author Adam Gurgul
+ */
+public class SourceTargetMapperTest {
+
+    public SourceTargetMapperTest() {
+    }
+
+    /**
+     * Test of toTarget method, of class SourceTargetMapper.
+     */
+    @Test
+    public void testMapperOnExistingIpAndServer() {
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("ip", "127.0.0.1");
+        map.put("server", "168.192.1.1");
+
+        Source s = new Source(map);
+        Target t = SourceTargetMapper.MAPPER.toTarget( s );
+
+        assertEquals(t.getIp(), "127.0.0.1");
+        assertEquals(t.getServer(), "168.192.1.1");
+
+    }
+
+    @Test
+    public void testMapperOnNonExistingIpAndServer() {
+
+        Map<String, Object> map = new HashMap<>();
+        Source s = new Source(map);
+        Target t = SourceTargetMapper.MAPPER.toTarget( s );
+
+        assertNull(t.getIp());
+        assertNull(t.getServer());
+
+    }
+
+
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <module>mapstruct-field-mapping</module>
         <module>mapstruct-iterable-to-non-iterable</module>
         <module>mapstruct-lombok</module>
+        <module>mapstruct-mapping-from-map</module>
         <module>mapstruct-mapping-with-cycles</module>
         <module>mapstruct-nested-bean-mappings</module>
         <module>mapstruct-rounding</module>


### PR DESCRIPTION
*Added Source class with single field: Map<String, Object>,
*Added Target class with two fields, String ip and String server,
*Added MappingUtil with two interfaces for each of the properties,
*Added SourceTargetMapper,
*Covered with positive and negative tests.
*Updated README file