### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ matrix:
   - jdk: openjdk8
   - jdk: oraclejdk8
   - jdk: openjdk10
+    # For some reason pulling from sonatype_snapshots does not work for openjdk10 and we have to manually symlink
+    # See https://github.com/travis-ci/travis-ci/issues/9368#issuecomment-405070163
+    before_install:
+      - rm "${JAVA_HOME}/lib/security/cacerts"
+      - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
   - jdk: openjdk11
   - jdk: openjdk-ea
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: java
+
+sudo: false
+dist: trusty
+
+install: true
+
+matrix:
+  include:
+  - jdk: openjdk8
+  - jdk: oraclejdk8
+  - jdk: openjdk10
+  - jdk: openjdk11
+  - jdk: openjdk-ea
+  allow_failures:
+  - jdk: openjdk-ea
+
+script: mvn clean verify -B -V -U
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/mapstruct-field-mapping/pom.xml
+++ b/mapstruct-field-mapping/pom.xml
@@ -27,7 +27,7 @@
     <version>1.0.0</version>
 
     <properties>
-        <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.3.0-SNAPSHOT</org.mapstruct.version>
     </properties>
 
     <dependencies>

--- a/mapstruct-iterable-to-non-iterable/pom.xml
+++ b/mapstruct-iterable-to-non-iterable/pom.xml
@@ -25,6 +25,11 @@
     <artifactId>mapstruct-examples-iterable-non-iterable</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/mapstruct-iterable-to-non-iterable/pom.xml
+++ b/mapstruct-iterable-to-non-iterable/pom.xml
@@ -35,13 +35,13 @@
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
-            <version>1.2.0.Final</version>
+            <version>1.3.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct-processor</artifactId>
-            <version>1.2.0.Final</version>
+            <version>1.3.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/mapstruct-jpa-child-parent/pom.xml
+++ b/mapstruct-jpa-child-parent/pom.xml
@@ -26,7 +26,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.3.0-SNAPSHOT</org.mapstruct.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>

--- a/mapstruct-jpa-child-parent/pom.xml
+++ b/mapstruct-jpa-child-parent/pom.xml
@@ -27,6 +27,8 @@
 
     <properties>
         <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/mapstruct-kotlin/pom.xml
+++ b/mapstruct-kotlin/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <kotlin.version>1.1.3-2</kotlin.version>
+        <kotlin.version>1.2.51</kotlin.version>
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <mapstruct.version>1.2.0.Final</mapstruct.version>
     </properties>

--- a/mapstruct-kotlin/pom.xml
+++ b/mapstruct-kotlin/pom.xml
@@ -16,7 +16,7 @@
 
         <kotlin.version>1.2.51</kotlin.version>
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
-        <mapstruct.version>1.2.0.Final</mapstruct.version>
+        <mapstruct.version>1.3.0-SNAPSHOT</mapstruct.version>
     </properties>
 
     <dependencies>

--- a/mapstruct-lombok/pom.xml
+++ b/mapstruct-lombok/pom.xml
@@ -31,7 +31,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.3.0-SNAPSHOT</org.mapstruct.version>
         <org.projectlombok.version>1.18.0</org.projectlombok.version>
     </properties>
 

--- a/mapstruct-lombok/pom.xml
+++ b/mapstruct-lombok/pom.xml
@@ -32,7 +32,7 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
-        <org.projectlombok.version>1.16.14</org.projectlombok.version>
+        <org.projectlombok.version>1.18.0</org.projectlombok.version>
     </properties>
 
     <dependencies>

--- a/mapstruct-lookup-entity-with-id/pom.xml
+++ b/mapstruct-lookup-entity-with-id/pom.xml
@@ -26,7 +26,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.3.0-SNAPSHOT</org.mapstruct.version>
     </properties>
 
     <dependencies>

--- a/mapstruct-mapping-from-map/pom.xml
+++ b/mapstruct-mapping-from-map/pom.xml
@@ -26,7 +26,7 @@
     <version>1.0.0</version>
 
     <properties>
-        <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.3.0-SNAPSHOT</org.mapstruct.version>
     </properties>
 
     <dependencies>

--- a/mapstruct-mapping-with-cycles/pom.xml
+++ b/mapstruct-mapping-with-cycles/pom.xml
@@ -27,7 +27,7 @@
     <version>1.0.0</version>
 
     <properties>
-        <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.3.0-SNAPSHOT</org.mapstruct.version>
     </properties>
 
     <dependencies>

--- a/mapstruct-nested-bean-mappings/pom.xml
+++ b/mapstruct-nested-bean-mappings/pom.xml
@@ -27,7 +27,7 @@
     <version>1.0.0</version>
 
     <properties>
-        <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.3.0-SNAPSHOT</org.mapstruct.version>
     </properties>
 
     <dependencies>

--- a/mapstruct-protobuf3/pom.xml
+++ b/mapstruct-protobuf3/pom.xml
@@ -32,7 +32,7 @@
         <os.mavenplugin.version>1.4.0.Final</os.mavenplugin.version>
         <protobuf.plugin.version>0.5.0</protobuf.plugin.version>
         <protobuf.java.version>3.2.0</protobuf.java.version>
-        <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.3.0-SNAPSHOT</org.mapstruct.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>

--- a/mapstruct-rounding/pom.xml
+++ b/mapstruct-rounding/pom.xml
@@ -26,7 +26,7 @@
     <version>1.0.0</version>
 
     <properties>
-        <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.3.0-SNAPSHOT</org.mapstruct.version>
     </properties>
 
     <dependencies>

--- a/mapstruct-spi-accessor-naming/pom.xml
+++ b/mapstruct-spi-accessor-naming/pom.xml
@@ -28,7 +28,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.3.0-SNAPSHOT</org.mapstruct.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>

--- a/mapstruct-updatemethods-1/pom.xml
+++ b/mapstruct-updatemethods-1/pom.xml
@@ -26,7 +26,7 @@
     <version>1.0.0</version>
 
     <properties>
-        <org.mapstruct.version>1.2.0.Final</org.mapstruct.version>
+        <org.mapstruct.version>1.3.0-SNAPSHOT</org.mapstruct.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
* Add Travis build with matrix for
  * openjdk8
  * oraclejdk8
  * openjdk10
  * openjdk11
  * openjdk-ea
* Use explicit maven compiler source and target version (source and target 1.5 have been removed from JDK10)
* Use latest version of Lombok (1.18.0) that works on Java 10
* Use latest version of Kotlin (1.2.51) that works on Java 10
* Use mapstruct 1.3.0-SNAPSHOT
* Manually symlink CA certs for openjdk10 to solve problem with https connections with sonatype_snapshots