### PR TITLE
Add simple Quarkus demo application

### DIFF
--- a/mapstruct-quarkus/README.md
+++ b/mapstruct-quarkus/README.md
@@ -1,0 +1,54 @@
+# MapStruct + Quarkus
+
+This example demonstrates how easy it is to use MapStruct in a [Quarkus](https://quarkus.io) application.
+
+The example was basically built with the following steps:
+
+1. Create a new Quarkus application
+
+   ```
+   mvn io.quarkus:quarkus-maven-plugin:0.11.0:create -DprojectGroupId=org.mapstruct.examples.quarkus -DprojectArtifactId=mapstruct-examples-quarkus -DclassName="org.mapstruct.example.quarkus.PersonResource" -Dpath="/person" -Dextensions="resteasy-jsonb"
+   ```
+
+2. Add MapStruct as described in the [reference guide](http://mapstruct.org/documentation/dev/reference/html/#_apache_maven)
+3. Set CDI as the default component-model (see [reference guide](http://mapstruct.org/documentation/dev/reference/html/#configuration-options))
+4. Define a mapper and inject it with `@Inject` in the service
+
+That's it!
+
+### Native images
+
+As MapStruct is not using reflection within the mappers native images are supported as long as CDI is used to retrieve the mappers.
+Just try to package your Quarkus application in a native image and feel the speed!
+
+```
+mvn package -Dnative
+```
+
+In case you prefer to use `Mappers.getMapper(...)` be aware that this is not automatically supported by native images. Internally the `getMapper` method uses reflection to retrieve the mapper implementation. This is the only place where MapStruct uses reflection and thus it causes issues with native images.
+
+There are some workarounds by defining additional metadata used during native image creation by GraalVM. For example you can create a `Feature` as described [here](https://github.com/oracle/graal/blob/master/substratevm/REFLECTION.md) and register all you mapper implementations and their constructor(s).
+
+For example if you just have a `FoobarMapper` the feature might look like this:
+
+```java
+@AutomaticFeature
+class MapstructMapperFeature implements Feature {
+  public void beforeAnalysis(BeforeAnalysisAccess access) {
+    try {
+      RuntimeReflection.register(FoobarMapperImpl.class);
+      RuntimeReflection.register(FoobarMapperImpl.class.getConstructors());
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}
+```
+
+_(As `FoobarMapperImpl` is a generated class you first have to generate your mappers before you can define this class, otherwise you will get compiliation issues)_
+
+
+### One drawback
+
+When using the Quarkus dev mode the mapper will not automatically be (re)generated.
+That means you have to compile (and restart) your application in case you made a change that affects the mapper.

--- a/mapstruct-quarkus/README.md
+++ b/mapstruct-quarkus/README.md
@@ -7,7 +7,12 @@ The example was basically built with the following steps:
 1. Create a new Quarkus application
 
    ```
-   mvn io.quarkus:quarkus-maven-plugin:0.11.0:create -DprojectGroupId=org.mapstruct.examples.quarkus -DprojectArtifactId=mapstruct-examples-quarkus -DclassName="org.mapstruct.example.quarkus.PersonResource" -Dpath="/person" -Dextensions="resteasy-jsonb"
+   mvn io.quarkus:quarkus-maven-plugin:0.15.0:create \
+     -DprojectGroupId=org.mapstruct.examples.quarkus \
+     -DprojectArtifactId=mapstruct-examples-quarkus \
+     -DclassName="org.mapstruct.example.quarkus.PersonResource" \
+     -Dpath="/person" \
+     -Dextensions="resteasy-jsonb"
    ```
 
 2. Add the `mapstruct-processor` as a regular `provided` scoped dependency and *not* as described in the 

--- a/mapstruct-quarkus/README.md
+++ b/mapstruct-quarkus/README.md
@@ -10,7 +10,18 @@ The example was basically built with the following steps:
    mvn io.quarkus:quarkus-maven-plugin:0.11.0:create -DprojectGroupId=org.mapstruct.examples.quarkus -DprojectArtifactId=mapstruct-examples-quarkus -DclassName="org.mapstruct.example.quarkus.PersonResource" -Dpath="/person" -Dextensions="resteasy-jsonb"
    ```
 
-2. Add MapStruct as described in the [reference guide](http://mapstruct.org/documentation/dev/reference/html/#_apache_maven)
+2. Add the `mapstruct-processor` as a regular `provided` scoped dependency and *not* as described in the 
+[reference guide](http://mapstruct.org/documentation/dev/reference/html/#_apache_maven)
+   
+   ```xml
+   <dependency>
+     <groupId>org.mapstruct</groupId>
+     <artifactId>mapstruct-processor</artifactId>
+     <version>${org.mapstruct.version}</version>
+     <scope>provided</scope>
+   </dependency>
+   ```
+
 3. Set CDI as the default component-model (see [reference guide](http://mapstruct.org/documentation/dev/reference/html/#configuration-options))
 4. Define a mapper and inject it with `@Inject` in the service
 
@@ -25,9 +36,12 @@ Just try to package your Quarkus application in a native image and feel the spee
 mvn package -Dnative
 ```
 
-In case you prefer to use `Mappers.getMapper(...)` be aware that this is not automatically supported by native images. Internally the `getMapper` method uses reflection to retrieve the mapper implementation. This is the only place where MapStruct uses reflection and thus it causes issues with native images.
+In case you prefer to use `Mappers.getMapper(...)` be aware that this is not automatically supported by native images. Internally the `getMapper` method uses reflection to 
+retrieve the mapper implementation. 
+This is the only place where MapStruct uses reflection and thus it causes issues with native images.
 
-There are some workarounds by defining additional metadata used during native image creation by GraalVM. For example you can create a `Feature` as described [here](https://github.com/oracle/graal/blob/master/substratevm/REFLECTION.md) and register all you mapper implementations and their constructor(s).
+There are some workarounds by defining additional metadata used during native image creation by GraalVM. For example you can create a `Feature` as described 
+[here](https://github.com/oracle/graal/blob/master/substratevm/REFLECTION.md) and register all you mapper implementations and their constructor(s).
 
 For example if you just have a `FoobarMapper` the feature might look like this:
 
@@ -50,5 +64,10 @@ _(As `FoobarMapperImpl` is a generated class you first have to generate your map
 
 ### One drawback
 
-When using the Quarkus dev mode the mapper will not automatically be (re)generated.
-That means you have to compile (and restart) your application in case you made a change that affects the mapper.
+When using the Quarkus dev mode the mapper will automatically be (re)generated in case you make change to the `@Mapper` annotated class.
+Changing a dependent class (like `PersonDto` in this example) will not (re)generate the mapper implementation.
+
+As a workaround you can quit the dev-mode, recompile and start the application once again or you can make a (temporary) change to the `@Mapper` annotated class so that it
+will be picked up and a valid implementation will be generated.
+
+*Pay attention*: You have to add the mapstruct-processor as described above and *not* using the `maven-compile-plugin`.

--- a/mapstruct-quarkus/pom.xml
+++ b/mapstruct-quarkus/pom.xml
@@ -91,9 +91,6 @@
               <version>${org.mapstruct.version}</version>
             </path>
           </annotationProcessorPaths>
-          <compilerArgs>
-            <compilerArg>-Amapstruct.defaultComponentModel=cdi</compilerArg>
-          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/mapstruct-quarkus/pom.xml
+++ b/mapstruct-quarkus/pom.xml
@@ -53,26 +53,21 @@
       <artifactId>mapstruct</artifactId>
       <version>${org.mapstruct.version}</version>
     </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy</artifactId>
+      <artifactId>quarkus-resteasy-jsonb</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-arc</artifactId>
-    </dependency>
+
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-jsonb</artifactId>
     </dependency>
   </dependencies>
 

--- a/mapstruct-quarkus/pom.xml
+++ b/mapstruct-quarkus/pom.xml
@@ -69,31 +69,24 @@
       <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mapstruct</groupId>
+      <artifactId>mapstruct-processor</artifactId>
+      <version>${org.mapstruct.version}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>
     <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <annotationProcessorPaths>
-            <path>
-              <groupId>org.mapstruct</groupId>
-              <artifactId>mapstruct-processor</artifactId>
-              <version>${org.mapstruct.version}</version>
-            </path>
-          </annotationProcessorPaths>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.version}</version>
         <executions>
           <execution>
+            <id>quarkus-build</id>
             <goals>
               <goal>build</goal>
             </goals>
@@ -153,6 +146,33 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- there is an issue with JDK12 and Quarkus, see https://github.com/quarkusio/quarkus/issues/1534 -->
+    <!-- so we will skip the quarkus plugin and tests for now in case jdk >= 12 -->
+    <profile>
+      <id>java12+</id>
+      <activation>
+        <jdk>[12,)</jdk>
+      </activation>
+      <properties>
+        <maven.test.skip>true</maven.test.skip>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${quarkus.version}</version>
+              <executions>
+                <execution>
+                  <id>quarkus-build</id>
+                  <phase>none</phase> <!-- invalid phase to disable this execution -->
+                </execution>
+              </executions>
           </plugin>
         </plugins>
       </build>

--- a/mapstruct-quarkus/pom.xml
+++ b/mapstruct-quarkus/pom.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0"?>
+<!--
+
+ Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ and/or other contributors as indicated by the @authors tag. See the
+ copyright.txt file in the distribution for a full listing of all
+ contributors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.mapstruct.examples.quarkus</groupId>
+  <artifactId>mapstruct-examples-quarkus</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <surefire-plugin.version>2.22.0</surefire-plugin.version>
+    <quarkus.version>0.11.0</quarkus.version>
+    <org.mapstruct.version>1.3.0.Final</org.mapstruct.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${quarkus.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.mapstruct</groupId>
+      <artifactId>mapstruct</artifactId>
+      <version>${org.mapstruct.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jsonb</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.mapstruct</groupId>
+              <artifactId>mapstruct-processor</artifactId>
+              <version>${org.mapstruct.version}</version>
+            </path>
+          </annotationProcessorPaths>
+          <compilerArgs>
+            <compilerArg>-Amapstruct.defaultComponentModel=cdi</compilerArg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire-plugin.version}</version>
+        <configuration>
+          <systemProperties>
+            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+          </systemProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>native</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-maven-plugin</artifactId>
+            <version>${quarkus.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>native-image</goal>
+                </goals>
+                <configuration>
+                  <enableHttpUrlHandler>true</enableHttpUrlHandler>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${surefire-plugin.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <systemProperties>
+                    <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                  </systemProperties>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/mapstruct-quarkus/pom.xml
+++ b/mapstruct-quarkus/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <quarkus.version>0.11.0</quarkus.version>
+    <quarkus.version>0.15.0</quarkus.version>
     <org.mapstruct.version>1.3.0.Final</org.mapstruct.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/PersonResource.java
+++ b/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/PersonResource.java
@@ -25,8 +25,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.mapstruct.example.quarkus.mapper.PersonMapper;
-import org.mapstruct.example.quarkus.resource.PersonDto;
-import org.mapstruct.example.quarkus.service.Person;
+import org.mapstruct.example.quarkus.dto.PersonDto;
 import org.mapstruct.example.quarkus.service.PersonService;
 
 @Path("/person")

--- a/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/PersonResource.java
+++ b/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/PersonResource.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.example.quarkus;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.mapstruct.example.quarkus.mapper.PersonMapper;
+import org.mapstruct.example.quarkus.resource.PersonDto;
+import org.mapstruct.example.quarkus.service.Person;
+import org.mapstruct.example.quarkus.service.PersonService;
+
+@Path("/person")
+public class PersonResource {
+
+    @Inject
+    PersonService personService;
+
+    @Inject
+    PersonMapper personMapper;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public PersonDto loadPerson() {
+        return personMapper.toResource( personService.loadPerson() );
+    }
+}

--- a/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/dto/PersonDto.java
+++ b/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/dto/PersonDto.java
@@ -16,15 +16,25 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.example.quarkus.mapper;
+package org.mapstruct.example.quarkus.dto;
 
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.example.quarkus.dto.PersonDto;
-import org.mapstruct.example.quarkus.service.Person;
+public class PersonDto {
+    private String firstname;
+    private String surname;
 
-@Mapper(config = QuarkusMappingConfig.class)
-public interface PersonMapper {
-    @Mapping(target = "surname", source = "lastname")
-    PersonDto toResource(Person person);
+    public String getFirstname() {
+        return firstname;
+    }
+
+    public void setFirstname(String firstname) {
+        this.firstname = firstname;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
 }

--- a/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/mapper/PersonMapper.java
+++ b/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/mapper/PersonMapper.java
@@ -1,0 +1,30 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.example.quarkus.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.example.quarkus.resource.PersonDto;
+import org.mapstruct.example.quarkus.service.Person;
+
+@Mapper
+public interface PersonMapper {
+    @Mapping( target="surname", source="lastname" )
+    PersonDto toResource(Person person);
+}

--- a/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/mapper/QuarkusMappingConfig.java
+++ b/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/mapper/QuarkusMappingConfig.java
@@ -16,25 +16,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.example.quarkus.resource;
+package org.mapstruct.example.quarkus.mapper;
 
-public class PersonDto {
-    private String firstname;
-    private String surname;
+import org.mapstruct.MapperConfig;
 
-    public String getFirstname() {
-        return firstname;
-    }
-
-    public void setFirstname(String firstname) {
-        this.firstname = firstname;
-    }
-
-    public String getSurname() {
-        return surname;
-    }
-
-    public void setSurname(String surname) {
-        this.surname = surname;
-    }
+@MapperConfig(componentModel = "cdi")
+interface QuarkusMappingConfig {
 }

--- a/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/resource/PersonDto.java
+++ b/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/resource/PersonDto.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.example.quarkus.resource;
+
+public class PersonDto {
+    private String firstname;
+    private String surname;
+
+    public String getFirstname() {
+        return firstname;
+    }
+
+    public void setFirstname(String firstname) {
+        this.firstname = firstname;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+}

--- a/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/service/Person.java
+++ b/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/service/Person.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.example.quarkus.service;
+
+public class Person {
+    private String firstname;
+    private String lastname;
+
+    public Person(String firstname, String lastname) {
+        this.firstname = firstname;
+        this.lastname = lastname;
+    }
+
+    public String getFirstname() {
+        return firstname;
+    }
+
+    public String getLastname() {
+        return lastname;
+    }
+}

--- a/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/service/PersonService.java
+++ b/mapstruct-quarkus/src/main/java/org/mapstruct/example/quarkus/service/PersonService.java
@@ -1,0 +1,30 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.example.quarkus.service;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PersonService {
+
+    public Person loadPerson() {
+        return new Person("Bob", "Miller");
+    }
+
+}

--- a/mapstruct-quarkus/src/test/java/org/mapstruct/example/quarkus/NativePersonResourceIT.java
+++ b/mapstruct-quarkus/src/test/java/org/mapstruct/example/quarkus/NativePersonResourceIT.java
@@ -1,0 +1,27 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.example.quarkus;
+
+import io.quarkus.test.junit.SubstrateTest;
+
+@SubstrateTest
+public class NativePersonResourceIT extends PersonResourceTest {
+
+    // Execute the same tests but in native mode.
+}

--- a/mapstruct-quarkus/src/test/java/org/mapstruct/example/quarkus/PersonResourceTest.java
+++ b/mapstruct-quarkus/src/test/java/org/mapstruct/example/quarkus/PersonResourceTest.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.example.quarkus;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+
+@QuarkusTest
+public class PersonResourceTest {
+
+    @Test
+    public void testPersonEndpoint() {
+        given()
+            .when().get("/person")
+            .then()
+            .statusCode(200)
+            .body( "firstname", is("Bob") )
+            .body("surname", is("Miller") );
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -45,5 +45,6 @@
         <module>mapstruct-suppress-unmapped</module>
         <module>mapstruct-clone</module>
         <module>mapstruct-mapper-repo</module>
+        <module>mapstruct-quarkus</module>
     </modules>
 </project>


### PR DESCRIPTION
As already mentioned in @gunnarmorling thread on [Twitter](https://twitter.com/cbandowski/status/1105951913558839296) I created a small example using MapStruct together with Quarkus.

This here is the result. I thought it might be good to have this in our examples repo, even if there is really nothing special.

I also added a README containing a few more information.

The example itself just ramps up a small web-app that uses a `PersonService` that returns a `Person` object, mapping it to a `PersonDto` and sends the result to the caller.

Should we add this here? WDYT?