### PR TITLE
Could org.mapstruct.examples.kotlin:mapstruct-examples-kotlin:1.0.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/mapstruct-kotlin/pom.xml
+++ b/mapstruct-kotlin/pom.xml
@@ -28,12 +28,16 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <version>${kotlin.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
-            <version>${kotlin.version}</version>
-            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -47,6 +51,13 @@
             <version>3.8.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency> 
+            <groupId>org.jetbrains.kotlin</groupId>  
+            <artifactId>kotlin-test</artifactId>  
+            <version>1.5.10</version>  
+            <type>jar</type>  
+            <scope>test</scope> 
+        </dependency> 
     </dependencies>
 
     <build>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78527112/167534157-22784b0f-83a2-47df-affc-dd97d10d6743.png)
Hi! I found the pom file of project **_org.mapstruct.examples.kotlin:mapstruct-examples-kotlin:1.0.0-SNAPSHOT_** introduced **_10_** dependencies. However, among them, **_3_** libraries (**_30%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.5.10:compile
org.jetbrains.kotlin:kotlin-test-junit:jar:1.5.10:test
org.jetbrains:annotations:jar:13.0:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, As such, I suggest a refactoring operation for **_org.mapstruct.examples.kotlin:mapstruct-examples-kotlin:1.0.0-SNAPSHOT_**’s pom file.

As shown in the figure, it is noteworthy that, libraries **_org.jetbrains.kotlin:kotlin-test::1.5.10:test(130KB)_** are invoked by the projects. When we remove the redundant dependency **_org.jetbrains.kotlin:kotlin-test-junit::1.5.10:test_**, the above **_org.jetbrains.kotlin:kotlin-test::1.5.10:test(130KB)_** should be declared as direct dependencies. The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_org.mapstruct.examples.kotlin:mapstruct-examples-kotlin:1.0.0-SNAPSHOT_**’s maven tests.

Best regards