### PR TITLE
Misspelling correction

### DIFF
--- a/mapstruct-iterable-to-non-iterable/src/main/java/com/mycompany/mapper/SourceTargetMapper.java
+++ b/mapstruct-iterable-to-non-iterable/src/main/java/com/mycompany/mapper/SourceTargetMapper.java
@@ -6,14 +6,14 @@
 package com.mycompany.mapper;
 
 import com.mycompany.mapper.util.FirstElement;
-import com.mycompany.mapper.util.IterableNonInterableUtil;
+import com.mycompany.mapper.util.IterableNonIterableUtil;
 import com.mycompany.mapper.util.LastElement;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 
-@Mapper( uses = IterableNonInterableUtil.class )
+@Mapper( uses = IterableNonIterableUtil.class )
 public interface SourceTargetMapper {
 
     SourceTargetMapper MAPPER = Mappers.getMapper( SourceTargetMapper.class );

--- a/mapstruct-iterable-to-non-iterable/src/main/java/com/mycompany/mapper/util/IterableNonIterableUtil.java
+++ b/mapstruct-iterable-to-non-iterable/src/main/java/com/mycompany/mapper/util/IterableNonIterableUtil.java
@@ -12,7 +12,7 @@ import java.util.List;
  *
  * @author Sjaak Derksen
  */
-public class IterableNonInterableUtil {
+public class IterableNonIterableUtil {
 
     @FirstElement
     public <T> T first( List<T> in ) {


### PR DESCRIPTION
there is a misspelling in the example mapstruct-examples-iterable-non-iterable, NonInterable should be NonIterable