### PR TITLE
Consistently use ext variable for version

### DIFF
--- a/mapstruct-on-gradle/build.gradle
+++ b/mapstruct-on-gradle/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 dependencies {
     implementation "org.mapstruct:mapstruct:${mapstructVersion}"
     testImplementation "org.testng:testng:6.10", "org.easytesting:fest-assert:1.4"
-    annotationProcessor "org.mapstruct:mapstruct-processor:1.5.3.Final"
+    annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
Use the `mapstructVersion` variable everywhere within the file