### PR TITLE
Fix order of target and source in mapping annotation

### DIFF
--- a/mapstruct-field-mapping/src/main/java/org/mapstruct/example/mapper/CustomerMapper.java
+++ b/mapstruct-field-mapping/src/main/java/org/mapstruct/example/mapper/CustomerMapper.java
@@ -20,8 +20,8 @@ public interface CustomerMapper {
 
     CustomerMapper MAPPER = Mappers.getMapper( CustomerMapper.class );
 
-    @Mapping(source = "orders", target = "orderItems")
-    @Mapping(source = "customerName", target = "name")
+    @Mapping(target = "orderItems", source = "orders")
+    @Mapping(target = "name", source = "customerName")
     Customer toCustomer(CustomerDto customerDto);
 
     @InheritInverseConfiguration

--- a/mapstruct-iterable-to-non-iterable/src/main/java/com/mycompany/mapper/SourceTargetMapper.java
+++ b/mapstruct-iterable-to-non-iterable/src/main/java/com/mycompany/mapper/SourceTargetMapper.java
@@ -18,7 +18,7 @@ public interface SourceTargetMapper {
 
     SourceTargetMapper MAPPER = Mappers.getMapper( SourceTargetMapper.class );
 
-    @Mapping( source = "myIntegers", target = "myInteger", qualifiedBy = FirstElement.class )
-    @Mapping( source = "myStrings", target = "myString", qualifiedBy = LastElement.class )
+    @Mapping( target = "myInteger", source = "myIntegers", qualifiedBy = FirstElement.class )
+    @Mapping( target = "myString", source = "myStrings", qualifiedBy = LastElement.class )
     Target toTarget( Source s );
 }

--- a/mapstruct-kotlin-gradle/src/main/kotlin/org/mapstruct/example/kotlin/converter/PersonConverter.kt
+++ b/mapstruct-kotlin-gradle/src/main/kotlin/org/mapstruct/example/kotlin/converter/PersonConverter.kt
@@ -9,7 +9,7 @@ import org.mapstruct.example.kotlin.model.Person
 @Mapper
 interface PersonConverter {
 
-    @Mapping(source = "phoneNumber", target = "phone")
+    @Mapping(target = "phone", source = "phoneNumber")
     fun convertToDto(person: Person): PersonDto
 
     @InheritInverseConfiguration

--- a/mapstruct-kotlin/README.md
+++ b/mapstruct-kotlin/README.md
@@ -20,7 +20,7 @@ The MapStruct converter:
 @Mapper
 interface PersonConverter {
 
-    @Mapping(source = "phoneNumber", target = "phone")
+    @Mapping(target = "phone", source = "phoneNumber")
     fun convertToDto(person: Person) : PersonDto
 
     @InheritInverseConfiguration

--- a/mapstruct-kotlin/src/main/kotlin/org/mapstruct/example/kotlin/converter/PersonConverter.kt
+++ b/mapstruct-kotlin/src/main/kotlin/org/mapstruct/example/kotlin/converter/PersonConverter.kt
@@ -9,7 +9,7 @@ import org.mapstruct.example.kotlin.model.Person
 @Mapper
 interface PersonConverter {
 
-    @Mapping(source = "phoneNumber", target = "phone")
+    @Mapping(target = "phone", source = "phoneNumber")
     fun convertToDto(person: Person): PersonDto
 
     @InheritInverseConfiguration

--- a/mapstruct-lombok/src/main/java/com/mycompany/mapper/SourceTargetMapper.java
+++ b/mapstruct-lombok/src/main/java/com/mycompany/mapper/SourceTargetMapper.java
@@ -17,6 +17,6 @@ public interface SourceTargetMapper {
 
     SourceTargetMapper MAPPER = Mappers.getMapper( SourceTargetMapper.class );
 
-    @Mapping( source = "test", target = "testing" )
+    @Mapping( target = "testing", source = "test" )
     Target toTarget( Source s );
 }

--- a/mapstruct-mapper-repo/example/src/main/java/org/mapstruct/example/repo/mappers/CarMapper.java
+++ b/mapstruct-mapper-repo/example/src/main/java/org/mapstruct/example/repo/mappers/CarMapper.java
@@ -19,6 +19,6 @@ import org.mapstruct.example.repo.domain.CarDto;
 @Mapper(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface CarMapper extends StandardMapper<Car, CarDto> {
 
-	@Mapping(source = "numberOfSeats", target = "seatCount")
+	@Mapping(target = "seatCount", source = "numberOfSeats")
 	CarDto map(Car Car);
 }

--- a/mapstruct-mapper-repo/example/src/main/java/org/mapstruct/example/repo/mappers/PersonMapper.java
+++ b/mapstruct-mapper-repo/example/src/main/java/org/mapstruct/example/repo/mappers/PersonMapper.java
@@ -18,6 +18,6 @@ import org.mapstruct.example.repo.domain.Person;
 @Mapper
 public interface PersonMapper extends StandardMapper<Person, Employee> {
 
-	@Mapping(source = "firstName", target = "name")
+	@Mapping(target = "name", source = "firstName")
 	Employee map(Person p);
 }

--- a/mapstruct-mapper-repo/example/src/main/java/org/mapstruct/example/repo/mappers/PersonToBossMapper.java
+++ b/mapstruct-mapper-repo/example/src/main/java/org/mapstruct/example/repo/mappers/PersonToBossMapper.java
@@ -18,7 +18,7 @@ import org.mapstruct.example.repo.domain.Person;
 @Mapper
 public interface PersonToBossMapper extends StandardMapper<Person, Boss> {
 
-	@Mapping(source = "firstName", target = "name")
+	@Mapping(target = "name", source = "firstName")
 	@Mapping(target = "title", constant = "Boss")
 	Boss map(Person p);
 }

--- a/mapstruct-mapping-from-map/src/main/java/org/mapstruct/example/mapper/SourceTargetMapper.java
+++ b/mapstruct-mapping-from-map/src/main/java/org/mapstruct/example/mapper/SourceTargetMapper.java
@@ -24,7 +24,7 @@ public interface SourceTargetMapper {
 
     SourceTargetMapper MAPPER = Mappers.getMapper( SourceTargetMapper.class );
 
-    @Mapping(source = "map", target = "ip", qualifiedBy = Ip.class )
-    @Mapping(source = "map", target = "server", qualifiedBy = Server.class )
+    @Mapping(target = "ip", source = "map", qualifiedBy = Ip.class )
+    @Mapping(target = "server", source = "map", qualifiedBy = Server.class )
     Target toTarget(Source s);
 }

--- a/mapstruct-mapping-with-cycles/src/main/java/org/mapstruct/example/mapper/EmployeeMapper.java
+++ b/mapstruct-mapping-with-cycles/src/main/java/org/mapstruct/example/mapper/EmployeeMapper.java
@@ -21,7 +21,7 @@ public interface EmployeeMapper {
 
     EmployeeMapper MAPPER = Mappers.getMapper( EmployeeMapper.class );
 
-    @Mapping(source = "employeeName", target = "name")
+    @Mapping(target = "name", source = "employeeName")
     Employee toEmployee(EmployeeDto employeeDto, @Context CycleAvoidingMappingContext context);
 
     @InheritInverseConfiguration

--- a/mapstruct-on-ant/src/main/java/org/mapstruct/example/SourceTargetMapper.java
+++ b/mapstruct-on-ant/src/main/java/org/mapstruct/example/SourceTargetMapper.java
@@ -15,8 +15,8 @@ public interface SourceTargetMapper {
 
     SourceTargetMapper INSTANCE = Mappers.getMapper(SourceTargetMapper.class);
 
-    @Mapping(source = "qax", target = "baz")
-    @Mapping(source = "baz", target = "qax")
+    @Mapping(target = "baz", source = "qax")
+    @Mapping(target = "qax", source = "baz")
     Target sourceToTarget(Source source);
 
     @InheritInverseConfiguration

--- a/mapstruct-on-bazel/src/main/java/org/mapstruct/example/SourceTargetMapper.java
+++ b/mapstruct-on-bazel/src/main/java/org/mapstruct/example/SourceTargetMapper.java
@@ -15,8 +15,8 @@ public interface SourceTargetMapper {
 
     SourceTargetMapper INSTANCE = Mappers.getMapper(SourceTargetMapper.class);
 
-    @Mapping(source = "qax", target = "baz")
-    @Mapping(source = "baz", target = "qax")
+    @Mapping(target = "baz", source = "qax")
+    @Mapping(target = "qax", source = "baz")
     Target sourceToTarget(Source source);
 
     @InheritInverseConfiguration

--- a/mapstruct-on-gradle-protobuf3/usage/src/main/java/org/mapstruct/example/mapper/UserMapper.java
+++ b/mapstruct-on-gradle-protobuf3/usage/src/main/java/org/mapstruct/example/mapper/UserMapper.java
@@ -29,14 +29,14 @@ public interface UserMapper {
     UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
 
 
-    @Mapping(source = "permissions", target = "permissionsList")
-    @Mapping(source = "mainDepartments", target = "mainDepartmentsList")
-    @Mapping(source = "departments", target = "departmentsList")
+    @Mapping(target = "permissionsList", source = "permissions")
+    @Mapping(target = "mainDepartmentsList", source = "mainDepartments")
+    @Mapping(target = "departmentsList", source = "departments")
     UserDTO map(User user);
 
-    @Mapping(source = "permissionsList", target = "permissions")
-    @Mapping(source = "mainDepartmentsList", target = "mainDepartments")
-    @Mapping(source = "departmentsList", target = "departments")
+    @Mapping(target = "permissions", source = "permissionsList")
+    @Mapping(target = "mainDepartments", source = "mainDepartmentsList")
+    @Mapping(target = "departments", source = "departmentsList")
     User map(UserDTO userDTO);
 
     @ValueMapping(source = "UNRECOGNIZED", target = MappingConstants.NULL)

--- a/mapstruct-on-gradle-protobuf3/usage/src/main/java/org/mapstruct/example/mapper/UserMapper.java
+++ b/mapstruct-on-gradle-protobuf3/usage/src/main/java/org/mapstruct/example/mapper/UserMapper.java
@@ -39,7 +39,7 @@ public interface UserMapper {
     @Mapping(target = "departments", source = "departmentsList")
     User map(UserDTO userDTO);
 
-    @ValueMapping(source = "UNRECOGNIZED", target = MappingConstants.NULL)
+    @ValueMapping(target = MappingConstants.NULL, source = "UNRECOGNIZED")
     Permission map(PermissionDTO permissionDTO);
 
     PermissionDTO map(Permission perm);

--- a/mapstruct-on-gradle/src/main/java/org/mapstruct/example/SourceTargetMapper.java
+++ b/mapstruct-on-gradle/src/main/java/org/mapstruct/example/SourceTargetMapper.java
@@ -15,8 +15,8 @@ public interface SourceTargetMapper {
 
     SourceTargetMapper INSTANCE = Mappers.getMapper(SourceTargetMapper.class);
 
-    @Mapping(source = "qax", target = "baz")
-    @Mapping(source = "baz", target = "qax")
+    @Mapping(target = "baz", source = "qax")
+    @Mapping(target = "qax", source = "baz")
     Target sourceToTarget(Source source);
 
     @InheritInverseConfiguration

--- a/mapstruct-protobuf3/usage/src/main/java/org/mapstruct/example/mapper/UserMapper.java
+++ b/mapstruct-protobuf3/usage/src/main/java/org/mapstruct/example/mapper/UserMapper.java
@@ -29,14 +29,14 @@ public interface UserMapper {
     UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
 
 
-    @Mapping(source = "permissions", target = "permissionsList")
-    @Mapping(source = "mainDepartments", target = "mainDepartmentsList")
-    @Mapping(source = "departments", target = "departmentsList")
+    @Mapping(target = "permissionsList", source = "permissions")
+    @Mapping(target = "mainDepartmentsList", source = "mainDepartments")
+    @Mapping(target = "departmentsList", source = "departments")
     UserDTO map(User user);
 
-    @Mapping(source = "permissionsList", target = "permissions")
-    @Mapping(source = "mainDepartmentsList", target = "mainDepartments")
-    @Mapping(source = "departmentsList", target = "departments")
+    @Mapping(target = "permissions", source = "permissionsList")
+    @Mapping(target = "mainDepartments", source = "mainDepartmentsList")
+    @Mapping(target = "departments", source = "departmentsList")
     User map(UserDTO userDTO);
 
     @ValueMapping(source = "UNRECOGNIZED", target = MappingConstants.NULL)

--- a/mapstruct-protobuf3/usage/src/main/java/org/mapstruct/example/mapper/UserMapper.java
+++ b/mapstruct-protobuf3/usage/src/main/java/org/mapstruct/example/mapper/UserMapper.java
@@ -39,7 +39,7 @@ public interface UserMapper {
     @Mapping(target = "departments", source = "departmentsList")
     User map(UserDTO userDTO);
 
-    @ValueMapping(source = "UNRECOGNIZED", target = MappingConstants.NULL)
+    @ValueMapping(target = MappingConstants.NULL, source = "UNRECOGNIZED")
     Permission map(PermissionDTO permissionDTO);
 
     PermissionDTO map(Permission perm);


### PR DESCRIPTION
Based on this discussion (https://groups.google.com/g/mapstruct-users/c/dM_ZGPJ_JlU/m/K8Gh0gybBQAJ) it appears that exists a non-written (?) rule saying that the standard way to write mappings is `target, source` (and not `source, target`).

A previous PR (https://github.com/mapstruct/mapstruct/pull/2369) fixed the web documentation, but the example code on this repo remained unchanged.

This pr's purpose is just to switch the `@Mapping(source,target)` into `@Mapping(target,source)`.
But additionally, for consistency, I also changed the `@ValueMapping(source,target)` into `@ValueMapping(target,source)`. If this second change is not desired, I can just revert that individual commit.